### PR TITLE
Payers input styling, personal avatars & colors, remove item button

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "boring-avatars": "^1.7.0",
     "classnames": "^2.3.2",
     "color-hash": "^2.0.2",
     "next": "13.1.6",

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -4,15 +4,21 @@ import {
   useFormContext,
   useWatch,
 } from "react-hook-form";
-import type { ValueContainerProps } from "react-select";
+import type {
+  ControlProps,
+  GroupBase,
+  ValueContainerProps,
+} from "react-select";
 import Select, { components } from "react-select";
 import type { Option } from "../contexts/PeopleContext";
 import { usePeople } from "../contexts/PeopleContext";
 
-import { Plus } from "react-feather";
-import { type FC, useEffect } from "react";
+import { Plus, Trash2 } from "react-feather";
 import { useMemo } from "react";
+import type { FC } from "react";
 import type { FormValues } from "../contexts/Form";
+import clx from "classnames";
+import PersonAvatar from "./PersonAvatar";
 
 const ValueContainer = ({
   children,
@@ -20,21 +26,13 @@ const ValueContainer = ({
 }: ValueContainerProps<Option>) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const [values, input] = children as any;
-  const val = (i: number) => props.getValue()?.[i]?.label;
 
   return (
     <components.ValueContainer {...props}>
       {/* {values} */}
       {Array.isArray(values) &&
-        values.map((v, index) => (
-          <span
-            key={index}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-gray-600"
-          >
-            <span className="text-xs font-medium leading-none text-white">
-              {(val(index) as string).slice(0, 2)}
-            </span>
-          </span>
+        values.map((_, i) => (
+          <PersonAvatar key={i} person={props.getValue()[i]!} />
         ))}
 
       {input}
@@ -54,8 +52,8 @@ const PayersInput: FC<{ index: number }> = ({ index }) => {
   });
 
   return (
-    <div className="w-full shrink-0 grow basis-3/6">
-      <label className="mb-2 block text-sm font-medium dark:text-white">
+    <div className="h-full w-full shrink-0 grow basis-3/6">
+      <label className="mb-2 block border-gray-200 bg-zinc-900 bg-transparent text-sm font-medium dark:text-white">
         People
       </label>
       <Select
@@ -67,8 +65,31 @@ const PayersInput: FC<{ index: number }> = ({ index }) => {
         value={(value || []) as Option[]}
         options={people}
         onChange={onChange}
-        styles={{
-          control: (base) => ({ ...base, minHeight: "46px" }),
+        unstyled
+        classNames={{
+          container: () => clx("h-12"),
+          control: (state: ControlProps<Option, true, GroupBase<Option>>) =>
+            clx(
+              state.isFocused
+                ? "border-black dark:border-white"
+                : "border-gray-200 dark:border-zinc-700",
+              "w-full h-full rounded-md border-2 border-gray-200 pl-2  text-sm font-medium dark:bg-zinc-900 dark:text-white"
+            ),
+          indicatorsContainer: () => clx("text-zinc-900 dark:text-gray-200"),
+          clearIndicator: () => clx("px-2 cursor-pointer hover:opacity-75"),
+          dropdownIndicator: () => clx("px-2 cursor-pointer hover:opacity-75"),
+          indicatorSeparator: () =>
+            clx("bg-gray-200 dark:bg-zinc-700 px-[1px]"),
+
+          valueContainer: () => clx("h-full flex gap-2"),
+          menuList: () =>
+            clx(
+              "mt-2 border border-gray-100 bg-white overflow-hidden rounded-md py-2 dark:border-zinc-800 dark:bg-zinc-900 dark:text-white"
+            ),
+          option: () =>
+            clx(
+              "py-1 px-3 hover:bg-gray-100 hover:dark:bg-zinc-800 focus:dark:bg-zinc-800"
+            ),
         }}
       />
     </div>
@@ -105,13 +126,13 @@ const Results = () => {
                 <tr className="divide-x divide-gray-200 dark:divide-zinc-700 dark:bg-zinc-900">
                   <th
                     scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium uppercase text-zinc-500"
+                    className="w-3/5 px-6 py-3 text-left text-xs font-medium uppercase text-zinc-500"
                   >
                     Name
                   </th>
                   <th
                     scope="col"
-                    className="px-6 py-3 text-left text-xs font-medium uppercase text-zinc-500"
+                    className="w-2/5 px-6 py-3 text-left text-xs font-medium uppercase text-zinc-500"
                   >
                     Pay
                   </th>
@@ -165,21 +186,18 @@ export const ItemForm = () => {
     >
       <ul className="flex flex-col gap-4">
         {fields.map((item, index) => (
-          <li key={item.id} className="flex items-end gap-4">
-            <div className="w-full  basis-1/6">
+          <li key={item.id} className="flex h-full items-end gap-3">
+            <div className="w-full basis-3/12">
               <label className="mb-2 block text-sm font-medium dark:text-white">
                 Price
               </label>
               <div className="relative">
                 <input
                   type="text"
-                  className="w-full rounded-md border border-gray-200 py-2 px-4 pr-8 text-sm shadow-sm focus:z-10 focus:border-blue-500 focus:ring-blue-500 dark:border-zinc-700 dark:bg-zinc-900 dark:text-white"
+                  className="h-12 w-full rounded-md border-2 border-gray-200 px-4 pr-8 text-sm font-medium focus:border-black focus:outline-none focus:ring-black dark:border-zinc-700 dark:bg-zinc-900 dark:text-white focus:dark:border-white focus:dark:ring-white"
                   placeholder="0.00"
                   {...register(`cut.${index}.price`)}
                 />
-                {/* <div className="pointer-events-none absolute inset-y-0 left-0 z-20 flex items-center pl-4">
-                    <span className="text-zinc-500">€</span>
-                  </div> */}
                 <div className="pointer-events-none absolute inset-y-0 right-0 z-20 flex items-center pr-4">
                   <span className="text-zinc-500">€</span>
                 </div>
@@ -188,8 +206,12 @@ export const ItemForm = () => {
 
             <PayersInput index={index} />
 
-            <button type="button" onClick={() => remove(index)}>
-              x
+            <button
+              className="h-12 rounded-md bg-red-600 px-1 text-white saturate-[75%] focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
+              type="button"
+              onClick={() => remove(index)}
+            >
+              <Trash2 width={20} />
             </button>
           </li>
         ))}

--- a/src/components/PeopleInput.tsx
+++ b/src/components/PeopleInput.tsx
@@ -2,13 +2,13 @@ import clx from "classnames";
 import type { KeyboardEventHandler } from "react";
 import { useId, useState } from "react";
 import { useFormContext } from "react-hook-form";
-import type { MultiValue } from "react-select";
+import type { ControlProps, GroupBase, MultiValue } from "react-select";
 
 import CreatableSelect from "react-select/creatable";
 import type { FormValues } from "../contexts/Form";
 import type { Option } from "../contexts/PeopleContext";
 import { usePeople } from "../contexts/PeopleContext";
-import { getRandomColor } from "../utils/colors";
+import { AVATARCOLORS, getRandomColor, shuffleArray } from "../utils/colors";
 
 const _components = {
   DropdownIndicator: null,
@@ -18,6 +18,7 @@ const createOption = (label: string) => ({
   label,
   value: label,
   color: getRandomColor(),
+  avatarColors: shuffleArray(AVATARCOLORS),
 });
 
 export const PeopleInput = () => {
@@ -66,24 +67,36 @@ export const PeopleInput = () => {
   return (
     <CreatableSelect
       id={id}
-      className="w-full"
+      className="h-full w-full"
       unstyled
       classNames={{
-        container: () => clx("border dark:border-zinc-700 rounded"),
-        control: () =>
-          clx("bg-white dark:bg-zinc-900 dark:text-white text-sm px-2 rounded"),
+        container: () => clx("h-12"),
+        control: (state: ControlProps<Option, true, GroupBase<Option>>) =>
+          clx(
+            state.isFocused
+              ? "border-black dark:border-white"
+              : "border-gray-200 dark:border-zinc-700",
+            "border-2 bg-white dark:bg-zinc-900 text-sm font-medium p-2 rounded-md dark:text-white"
+          ),
         multiValue: ({ data }) =>
           clx(`py-1 px-1.5 flex gap-1 rounded`, {
-            "bg-pink-50 text-pink-700": data.color === "pink",
-            "bg-red-50 text-red-700": data.color === "red",
-            "bg-orange-50 text-orange-700": data.color === "orange",
-            "bg-amber-50 text-amber-700": data.color === "amber",
-            "bg-emerald-50 text-emerald-700": data.color === "emerald",
-            "bg-cyan-50 text-cyan-700": data.color === "cyan",
-            "bg-indigo-50 text-indigo-700": data.color === "indigo",
+            "bg-pink-50 text-pink-800": data.color === "pink",
+            "bg-red-50 text-red-800": data.color === "red",
+            "bg-amber-50 text-amber-800": data.color === "amber",
+            "bg-emerald-50 text-emerald-800": data.color === "emerald",
+            "bg-cyan-50 text-cyan-800": data.color === "cyan",
+            "bg-indigo-50 text-indigo-800": data.color === "indigo",
+            "bg-lime-50 text-lime-800": data.color === "lime",
+            "bg-teal-50 text-teal-800": data.color === "teal",
+            "bg-blue-50 text-blue-800": data.color === "blue",
+            "bg-violet-50 text-violet-800": data.color === "violet",
           }),
 
         valueContainer: () => clx("flex gap-2"),
+        indicatorsContainer: () =>
+          clx(
+            "p-2 text-zinc-900 dark:text-gray-200 cursor-pointer hover:opacity-75"
+          ),
       }}
       components={_components}
       inputValue={inputValue}

--- a/src/components/PersonAvatar.tsx
+++ b/src/components/PersonAvatar.tsx
@@ -1,0 +1,16 @@
+import Avatar from "boring-avatars";
+import type { Option } from "../contexts/PeopleContext";
+
+const PersonAvatar = ({ person }: { person: Option }) => {
+  console.log(person);
+  return (
+    <div className="relative">
+      <Avatar size={32} variant="marble" colors={person.avatarColors} />
+      <span className="absolute inset-0 flex h-full w-full items-center justify-center text-base font-bold capitalize leading-none text-white">
+        {person.value.slice(0, 1)}
+      </span>
+    </div>
+  );
+};
+
+export default PersonAvatar;

--- a/src/contexts/Form.tsx
+++ b/src/contexts/Form.tsx
@@ -14,8 +14,8 @@ export const FormProvider: FC<PropsWithChildren> = ({ children }) => {
     defaultValues: {
       cut: [
         {
-          price: 10,
-          people: [{ value: "pantelis", label: "pantelis" }],
+          price: undefined,
+          people: [],
         },
       ],
     },

--- a/src/contexts/PeopleContext.tsx
+++ b/src/contexts/PeopleContext.tsx
@@ -1,5 +1,6 @@
 import type { Dispatch, FC, PropsWithChildren, SetStateAction } from "react";
 import type { Color } from "../utils/colors";
+import { AVATARCOLORS, shuffleArray } from "../utils/colors";
 
 import { createContext, useContext, useState } from "react";
 import { getRandomColor } from "../utils/colors";
@@ -7,7 +8,8 @@ import { getRandomColor } from "../utils/colors";
 export interface Option {
   readonly label: string;
   readonly value: string;
-  readonly color?: Color;
+  readonly color: Color;
+  readonly avatarColors: string[];
 }
 
 const PeopleContext = createContext<{
@@ -27,21 +29,25 @@ export const PeopleProvider: FC<PropsWithChildren> = ({ children }) => {
       value: "pantelis",
       label: "pantelis",
       color: getRandomColor(),
+      avatarColors: shuffleArray(AVATARCOLORS),
     },
     {
       value: "john",
       label: "john",
       color: getRandomColor(),
+      avatarColors: shuffleArray(AVATARCOLORS),
     },
     {
       value: "dimitris",
       label: "dimitris",
       color: getRandomColor(),
+      avatarColors: shuffleArray(AVATARCOLORS),
     },
     {
       value: "babis",
       label: "babis",
       color: getRandomColor(),
+      avatarColors: shuffleArray(AVATARCOLORS),
     },
   ]);
   return (

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,10 +1,13 @@
 export const COLORS = [
   "red",
-  "orange",
+  "lime",
   "amber",
   "emerald",
+  "teal",
   "cyan",
+  "blue",
   "indigo",
+  "violet",
   "pink",
 ] as const;
 
@@ -12,4 +15,21 @@ export type Color = (typeof COLORS)[number];
 
 export const getRandomColor = () => {
   return COLORS[Math.floor(Math.random() * COLORS.length)] as Color;
+};
+
+export const AVATARCOLORS = [
+  "#AE56FC",
+  "#009BFF",
+  "#00D3FF",
+  "#43FCE6",
+  "#CE0CD3",
+];
+
+export const shuffleArray = <T>(array: T[]): T[] => {
+  const newArray = [...array];
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [newArray[i], newArray[j]] = [array[j] as T, array[i] as T];
+  }
+  return newArray;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -655,6 +655,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+boring-avatars@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/boring-avatars/-/boring-avatars-1.7.0.tgz#70ac7146bbf37d8e69a35544b24f1d75558f868a"
+  integrity sha512-ZNHd8J7C/V0IjQMGQowLJ5rScEFU23WxePigH6rqKcT2Esf0qhYvYxw8s9i3srmlfCnCV00ddBjaoGey1eNOfA==
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"


### PR DESCRIPTION
This PR contains: 

- Focus states on all inputs (dark/light)
- Complete UI (both dark/light)
- Personal Avatars
- Updated colors
- General styling improvements
- A new delete Icon for item removal

![image](https://user-images.githubusercontent.com/85764745/217591699-51690696-e61f-412b-b015-689fb6ecfc71.png)
![image](https://user-images.githubusercontent.com/85764745/217591813-a454410d-4242-4871-b48d-a64761da9658.png)

![image](https://user-images.githubusercontent.com/85764745/217592302-0d95b34d-a6c9-4408-999c-d15a35d1d614.png)

![image](https://user-images.githubusercontent.com/85764745/217592555-9963ff3a-8b47-401f-806e-da771d0c9fa4.png)



