### PR TITLE
fix: Issue with NumberFormat beeing called without currency

### DIFF
--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -42,7 +42,9 @@ export const useCurrency = () => {
           setCurrency(currency);
         }
       })
-      .catch((e) => console.error(e))
+      .catch((e) => {
+        if(process.env.NODE_ENV !== 'production') console.error(e);
+      })
       .finally(() => (fetching[timezone] = false));
 
     return () => {

--- a/src/pages/api/currency.ts
+++ b/src/pages/api/currency.ts
@@ -9,9 +9,12 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
 
     const timezone = ct.getTimezone(_timezone);
     const country = timezone?.countries[0];
+
+    if (!country) return res.status(400).json({ message: "Could not match country with timezone" });
+
     const currency = countryToCurrency[country as keyof typeof countryToCurrency];
 
-    return res.status(200).json({ currency });
+    res.status(200).json({ currency });
   } else {
     res.status(403).json({ message: "Forbidden Method" });
   }


### PR DESCRIPTION
This PR solves the issue bellow that was throwing in production when Int.NumberFormat was called without a valid currency

![image](https://user-images.githubusercontent.com/19269911/218332800-3e85d74c-7608-4acb-89c2-c33d27cd5daf.png)
