### PR TITLE
Item index indicator, autocomplete fix, button focus state in dark mode

### DIFF
--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -101,14 +101,18 @@ export const ItemForm = () => {
       <ul className="flex flex-col gap-4">
         {fields.map((item, index) => (
           <li key={item.id} className="flex h-full items-end gap-3">
+            <span className="inline-flex h-12 items-center text-sm font-semibold text-zinc-400 dark:text-zinc-600">
+              {index + 1}
+            </span>
             <div className="w-full basis-3/12">
               <label className="mb-2 block text-sm font-medium dark:text-white">Price</label>
               <div className="relative">
                 <input
                   type="text"
+                  autoComplete="off"
                   inputMode="decimal"
                   className={classNames(
-                    `h-12 w-full rounded-md border px-4 pr-8 text-sm font-medium  focus:outline-none focus:ring-black dark:bg-zinc-900 dark:text-white focus:dark:ring-white`,
+                    `h-12 w-full rounded-md border px-4 pr-8 text-sm font-medium focus:outline-none focus:ring-black dark:bg-zinc-900 dark:text-white focus:dark:ring-white`,
                     {
                       "border-gray-200 focus:border-black dark:border-zinc-700 focus:dark:border-white ":
                         !errors?.cut?.[index]?.price?.message,
@@ -136,7 +140,7 @@ export const ItemForm = () => {
             <PayersInput index={index} />
 
             <button
-              className="h-12 rounded-md border border-transparent px-1 text-white transition-all hover:border-red-500 saturate-[75%] focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
+              className="h-12 rounded-md border border-transparent px-1 text-white saturate-[75%] transition-all hover:border-red-500 focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
               type="button"
               onClick={() => remove(index)}
             >
@@ -153,7 +157,7 @@ export const ItemForm = () => {
             `inline-flex grow items-center justify-center gap-2 rounded-md py-2 px-3 transition-all lg:grow-0`,
             `text-sm font-medium`,
             `border border-black bg-black text-white hover:bg-white hover:text-black dark:border-white dark:bg-white dark:text-black dark:hover:bg-black dark:hover:text-white`,
-            `focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-2 dark:focus:ring-white`,
+            `focus:outline-none focus:ring-2 focus:ring-black focus:ring-offset-2 focus:dark:ring-white focus:dark:ring-offset-black`,
           ])}
           onClick={() => append({ price: undefined, people: [] })}
         >


### PR DESCRIPTION
Changes:

**1. Items have an index on the left side.**

 **Before**
![image](https://user-images.githubusercontent.com/85764745/218456110-5f3d8206-71b0-405b-b8b0-bdb7b6be04ca.png)
**After**
![image](https://user-images.githubusercontent.com/85764745/218456879-f35906e4-2588-4ade-b59d-a05622155a66.png)

**2. Made autocomplete off in input price.**

**Before**
![image](https://user-images.githubusercontent.com/85764745/218456223-7351d964-2265-4d5a-b886-adaddcb837fa.png)
**After**
![image](https://user-images.githubusercontent.com/85764745/218456973-3274d875-9420-4fc8-9a33-a47d80c0d654.png)
**3. Fixed focus state of the 'New item' button in dark mode.**

**Before**
![image](https://user-images.githubusercontent.com/85764745/218456434-2d9aefda-a5b4-488c-a07b-d9fa727e509f.png)
**After**
![image](https://user-images.githubusercontent.com/85764745/218457103-91ec679e-3889-4312-be4e-be3826fb3f48.png)
